### PR TITLE
fix: MEDIA_IS_IN_USE EP-Subject korrekt als Array behandeln

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -85,11 +85,12 @@ rex_extension::register('MEDIA_IS_IN_USE', function(rex_extension_point $ep) {
     try {
         $sql->setQuery('SELECT filename FROM ' . rex::getTable('mediapool_tools_protected') . ' WHERE filename = ? LIMIT 1', [$filename]);
         if ($sql->getRows() > 0) {
-            $ep->setSubject(true);
-            $warning = $ep->getParam('warning');
-            if (!is_array($warning)) $warning = [];
+            $warning = $ep->getSubject();
+            if (!is_array($warning)) {
+                $warning = [];
+            }
             $warning[] = rex_i18n::rawMsg('mediapool_tools_media_protected_warning', $filename);
-            $ep->setParam('warning', $warning);
+            $ep->setSubject($warning);
         }
     } catch (rex_sql_exception $e) {
         // Tabelle existiert noch nicht -> keine Protection


### PR DESCRIPTION
## Problem

Der `MEDIA_IS_IN_USE` Extension-Point-Listener in `boot.php` setzte `$ep->setSubject(true)` — das ersetzte das Warning-Array mit einem Boolean.

Im REDAXO-Core wird `implode('', $warning)` auf das Subject aufgerufen (`mediapool.php` Zeile 100). Mit `true` statt einem Array führt das zu:

```
TypeError: implode(): Argument #2 ($array) must be of type ?array, true given
```

Das brach z.B. REST-API-Aufrufe von `rex_mediapool::mediaIsInUse()` mit HTTP 500.

## Fix

- `$ep->getSubject()` statt `$ep->getParam('warning')` verwenden
- Warning-String zum bestehenden Array hinzufügen
- Array mit `$ep->setSubject($warning)` korrekt zurückgeben

## Vorher (fehlerhaft)

```php
$ep->setSubject(true);
$warning = $ep->getParam('warning');
if (!is_array($warning)) $warning = [];
$warning[] = rex_i18n::rawMsg(...);
$ep->setParam('warning', $warning);
```

## Nachher (korrekt)

```php
$warning = $ep->getSubject();
if (!is_array($warning)) {
    $warning = [];
}
$warning[] = rex_i18n::rawMsg(...);
$ep->setSubject($warning);
```
