### PR TITLE
fix: scan shows all files unused on fast DBs; bulk move only shifts first file

### DIFF
--- a/assets/unused_media.js
+++ b/assets/unused_media.js
@@ -139,18 +139,6 @@ $(document).on('rex:ready', function (event, element) {
     
     // Verschieben
     $('#btn-move-selected').on('click', function() {
-        let files = getSelectedFiles();
-        // Prompt oder besseres UI für Kategorie Auswahl? 
-        // Wir nehmen hier das Element aus dem Footer
-        /* Da Prompt doof ist, haben wir unten im Footer ein Select gebaut, wir lesen das aus. */
-        /* Moment, im HTML unten müssen wir das Select bauen. */
-    });
-    
-    // Da ich das Dropdown für Move im HTML noch nicht kenne, baue ich es hier generisch ein:
-    // Der Button im HTML muss ein data-target haben oder wir nutzen ein Modal für die Zielkategorie.
-    // Einfacher: Ein Select neben dem Verschieben Button anzeigen?
-    
-    $('#btn-move-selected').on('click', function() {
          let targetCatId = $('select[name="target_category_id"]').val();
          let files = getSelectedFiles();
          

--- a/lib/ApiUnusedMedia.php
+++ b/lib/ApiUnusedMedia.php
@@ -175,22 +175,20 @@ class ApiUnusedMedia extends rex_api_function
         }
         
         $count = 0;
-        $sql = rex_sql::factory();
-        $sql->setTable(rex::getTable('media'));
-        
+
         foreach ($files as $file) {
-            // rex_media_service hat keine move Methode, wir machen es direkt SQL
-            // EPs beachten? Ja, MEDIA_UPDATED wäre gut.
-            // Aber Bulk-Update ist schneller via SQL und dann Cache clearen.
-            
+            $sql = rex_sql::factory();
+            $sql->setTable(rex::getTable('media'));
             $sql->setWhere(['filename' => $file]);
             $sql->setValue('category_id', $categoryId);
             $sql->setValue('updatedate', date('Y-m-d H:i:s'));
             $sql->setValue('updateuser', rex::getUser()->getLogin());
-            
+
             try {
                 $sql->update();
-                $count++;
+                if ($sql->getRows() > 0) {
+                    $count++;
+                }
                 \rex_media_cache::delete($file);
             } catch (\Exception $e) {
                 // Ignore errors

--- a/lib/UnusedMediaAnalysis.php
+++ b/lib/UnusedMediaAnalysis.php
@@ -124,7 +124,8 @@ class UnusedMediaAnalysis
         
         while (microtime(true) - $startTime < $maxTime) {
             if ($batch['currentTableIndex'] >= count($batch['tables'])) {
-                // Fertig!
+                // Fertig! Akkumulierten Stand vor Finalisierung speichern.
+                self::saveBatchStatus($batchId, $batch);
                 return self::finalizeAnalysis($batchId);
             }
 


### PR DESCRIPTION
## Summary

Two bugs found and fixed while using the addon on a small REDAXO installation:

- **Scan marks everything as unused on fast/small databases** — when all tables fit within a single `processNextStep()` AJAX call, `finalizeAnalysis()` was called before `saveBatchStatus()` had persisted the accumulated `foundFiles`. The finalizer then read the initial empty batch state, causing every media file to be reported as unused.

- **Bulk move only moves the first selected file** — `moveFiles()` created one `rex_sql` instance outside the loop and reused it across iterations. After the first `update()`, the internal WHERE state accumulated, making subsequent conditions unmatchable. Only the first file was ever actually moved. Fixed by creating a fresh `rex_sql` instance per file and counting only confirmed updates via `getRows() > 0`.

- **Dead click handler on move button** — a leftover stub `$('#btn-move-selected').on('click', ...)` with only comments in its body was registered before the real handler, resulting in two bindings on the button. Removed.

## Test plan

- [ ] Run unused media scan on a small DB where all tables scan in < 2 s — result should now correctly show only unreferenced files
- [ ] Select multiple files in the unused media list and move them to a category — all selected files should be moved, not just the first

🤖 Generated with [Claude Code](https://claude.ai/claude-code)